### PR TITLE
Add php-7.3 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
 - 7.1
 - 7.2
+- 7.3
 
 before_script:
 - composer install


### PR DESCRIPTION
# Changed log
- Add `php-7.3` test in Travis CI build because it's released by official PHP.